### PR TITLE
feat: add maxWidth msg option

### DIFF
--- a/lib/src/models/message_options.dart
+++ b/lib/src/models/message_options.dart
@@ -17,7 +17,7 @@ class MessageOptions {
     this.containerColor,
     this.textColor,
     this.messagePadding,
-    this.maxWidth = null,
+    this.maxWidth,
     this.messageDecorationBuilder,
     this.top,
     this.bottom,

--- a/lib/src/models/message_options.dart
+++ b/lib/src/models/message_options.dart
@@ -17,6 +17,7 @@ class MessageOptions {
     this.containerColor,
     this.textColor,
     this.messagePadding,
+    this.maxWidth = null,
     this.messageDecorationBuilder,
     this.top,
     this.bottom,
@@ -116,6 +117,10 @@ class MessageOptions {
   /// Padding arround the message
   /// Default to: EdgeInsets.all(11)
   final EdgeInsets? messagePadding;
+
+  /// Max message width
+  /// Default to: null, MediaQuery.of(context).size.width * 0.7
+  final double? maxWidth;
 
   /// When a message have both an text and a list of media
   /// it will determine which one th show first

--- a/lib/src/widgets/message_list/message_list.dart
+++ b/lib/src/widgets/message_list/message_list.dart
@@ -105,6 +105,7 @@ class _MessageListState extends State<MessageList> {
                             message: widget.messages[i],
                             nextMessage: nextMessage,
                             previousMessage: previousMessage,
+                            maxWidth: widget.messageOptions.maxWidth,
                             currentUser: widget.currentUser,
                             isAfterDateSeparator: isAfterDateSeparator,
                             isBeforeDateSeparator: isBeforeDateSeparator,

--- a/lib/src/widgets/message_list/message_list.dart
+++ b/lib/src/widgets/message_list/message_list.dart
@@ -105,7 +105,6 @@ class _MessageListState extends State<MessageList> {
                             message: widget.messages[i],
                             nextMessage: nextMessage,
                             previousMessage: previousMessage,
-                            maxWidth: widget.messageOptions.maxWidth,
                             currentUser: widget.currentUser,
                             isAfterDateSeparator: isAfterDateSeparator,
                             isBeforeDateSeparator: isBeforeDateSeparator,

--- a/lib/src/widgets/message_row/message_row.dart
+++ b/lib/src/widgets/message_row/message_row.dart
@@ -7,6 +7,7 @@ class MessageRow extends StatelessWidget {
     required this.currentUser,
     this.previousMessage,
     this.nextMessage,
+    this.maxWidth,
     this.isAfterDateSeparator = false,
     this.isBeforeDateSeparator = false,
     this.messageOptions = const MessageOptions(),
@@ -21,6 +22,9 @@ class MessageRow extends StatelessWidget {
 
   /// Next message in the list
   final ChatMessage? nextMessage;
+
+  // Max message width
+  final double? maxWidth;
 
   /// Current user of the chat
   final ChatUser currentUser;
@@ -87,7 +91,7 @@ class MessageRow extends StatelessWidget {
                 : null,
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                maxWidth: MediaQuery.of(context).size.width * 0.7,
+                maxWidth: maxWidth ?? MediaQuery.of(context).size.width * 0.7,
               ),
               child: Column(
                 crossAxisAlignment: isOwnMessage

--- a/lib/src/widgets/message_row/message_row.dart
+++ b/lib/src/widgets/message_row/message_row.dart
@@ -7,7 +7,6 @@ class MessageRow extends StatelessWidget {
     required this.currentUser,
     this.previousMessage,
     this.nextMessage,
-    this.maxWidth,
     this.isAfterDateSeparator = false,
     this.isBeforeDateSeparator = false,
     this.messageOptions = const MessageOptions(),
@@ -22,9 +21,6 @@ class MessageRow extends StatelessWidget {
 
   /// Next message in the list
   final ChatMessage? nextMessage;
-
-  // Max message width
-  final double? maxWidth;
 
   /// Current user of the chat
   final ChatUser currentUser;
@@ -91,7 +87,8 @@ class MessageRow extends StatelessWidget {
                 : null,
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                maxWidth: maxWidth ?? MediaQuery.of(context).size.width * 0.7,
+                maxWidth: messageOptions.maxWidth ??
+                    MediaQuery.of(context).size.width * 0.7,
               ),
               child: Column(
                 crossAxisAlignment: isOwnMessage


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

For some apps, chat window is a popup widget. It may be not suitable to use device's screen size. Instead user may want to set specified message max width, which is adapted to widget width.
