### PR TITLE
Replaced Container with SizedBox

### DIFF
--- a/lib/src/widgets/message_row/media_container.dart
+++ b/lib/src/widgets/message_row/media_container.dart
@@ -137,6 +137,6 @@ class MediaContainer extends StatelessWidget {
         ).toList(),
       );
     }
-    return Container();
+    return const SizedBox();
   }
 }


### PR DESCRIPTION
It is advised to use a SizedBox instead of a container to build empty spaces, because the SizedBox widget is much lighter.