### PR TITLE
Removed top safe area padding for the input widget.

### DIFF
--- a/lib/src/widgets/input_toolbar/input_toolbar.dart
+++ b/lib/src/widgets/input_toolbar/input_toolbar.dart
@@ -63,6 +63,7 @@ class _InputToolbarState extends State<InputToolbar>
   @override
   Widget build(BuildContext context) {
     return SafeArea(
+      top: false,
       child: Container(
         padding: widget.inputOptions.inputToolbarPadding,
         margin: widget.inputOptions.inputToolbarMargin,


### PR DESCRIPTION
Top safe area for the input widget should never be needed.