### PR TITLE
Bug Fix: Show mention OverlayEntry to relative to Overlay

### DIFF
--- a/lib/src/widgets/input_toolbar/input_toolbar.dart
+++ b/lib/src/widgets/input_toolbar/input_toolbar.dart
@@ -177,18 +177,15 @@ class InputToolbarState extends State<InputToolbar>
     final OverlayState overlay = Overlay.of(context);
     final RenderBox overlayRenderBox =
         overlay.context.findRenderObject() as RenderBox;
-    final RenderBox toolbarRenderBox = context.findRenderObject() as RenderBox;
-    final Offset toolBarGlobalOffset =
-        toolbarRenderBox.localToGlobal(Offset.zero);
-    final Offset overlayGlobalOffset =
-        overlayRenderBox.localToGlobal(Offset.zero);
-    final double toolbarTopLeftCornerOffset =
-        toolBarGlobalOffset.dy - overlayGlobalOffset.dy;
     final double overlayHeight = overlayRenderBox.size.height;
-    final double toolbarRelativeToOverlayOffset =
-        overlayHeight - toolbarTopLeftCornerOffset;
 
-    double bottomPosition = toolbarRelativeToOverlayOffset;
+    final RenderBox toolbarRenderBox = context.findRenderObject() as RenderBox;
+    final double toolBarY = toolbarRenderBox.localToGlobal(Offset.zero).dy;
+    final double overlayY = overlayRenderBox.localToGlobal(Offset.zero).dy;
+
+    final double toolbarRelativeOffset = overlayHeight - overlayY - toolBarY;
+
+    double bottomPosition = toolbarRelativeOffset;
     if (widget.inputOptions.inputToolbarMargin != null) {
       bottomPosition -= widget.inputOptions.inputToolbarMargin!.top -
           widget.inputOptions.inputToolbarMargin!.bottom;

--- a/lib/src/widgets/input_toolbar/input_toolbar.dart
+++ b/lib/src/widgets/input_toolbar/input_toolbar.dart
@@ -175,11 +175,20 @@ class InputToolbarState extends State<InputToolbar>
 
   void _showMentionModal(List<Widget> children) {
     final OverlayState overlay = Overlay.of(context);
-    final RenderBox renderBox = context.findRenderObject() as RenderBox;
-    final Offset topLeftCornerOffset = renderBox.localToGlobal(Offset.zero);
+    final RenderBox overlayRenderBox =
+        overlay.context.findRenderObject() as RenderBox;
+    final RenderBox toolbarRenderBox = context.findRenderObject() as RenderBox;
+    final Offset toolBarGlobalOffset =
+        toolbarRenderBox.localToGlobal(Offset.zero);
+    final Offset overlayGlobalOffset =
+        overlayRenderBox.localToGlobal(Offset.zero);
+    final double toolbarTopLeftCornerOffset =
+        toolBarGlobalOffset.dy - overlayGlobalOffset.dy;
+    final double overlayHeight = overlayRenderBox.size.height;
+    final double toolbarRelativeToOverlayOffset =
+        overlayHeight - toolbarTopLeftCornerOffset;
 
-    double bottomPosition =
-        MediaQuery.of(context).size.height - topLeftCornerOffset.dy;
+    double bottomPosition = toolbarRelativeToOverlayOffset;
     if (widget.inputOptions.inputToolbarMargin != null) {
       bottomPosition -= widget.inputOptions.inputToolbarMargin!.top -
           widget.inputOptions.inputToolbarMargin!.bottom;
@@ -190,7 +199,7 @@ class InputToolbarState extends State<InputToolbar>
     _overlayEntry = OverlayEntry(
       builder: (BuildContext context) {
         return Positioned(
-          width: renderBox.size.width,
+          width: toolbarRenderBox.size.width,
           bottom: bottomPosition,
           child: Container(
             constraints: BoxConstraints(

--- a/lib/src/widgets/input_toolbar/input_toolbar.dart
+++ b/lib/src/widgets/input_toolbar/input_toolbar.dart
@@ -177,15 +177,16 @@ class InputToolbarState extends State<InputToolbar>
     final OverlayState overlay = Overlay.of(context);
     final RenderBox overlayRenderBox =
         overlay.context.findRenderObject() as RenderBox;
-    final double overlayHeight = overlayRenderBox.size.height;
-
     final RenderBox toolbarRenderBox = context.findRenderObject() as RenderBox;
-    final double toolBarY = toolbarRenderBox.localToGlobal(Offset.zero).dy;
-    final double overlayY = overlayRenderBox.localToGlobal(Offset.zero).dy;
 
-    final double toolbarRelativeOffset = overlayHeight - overlayY - toolBarY;
+    final double toolbarOffsetY =
+        toolbarRenderBox.localToGlobal(Offset.zero).dy;
+    final double overlayOffsetY =
+        overlayRenderBox.localToGlobal(Offset.zero).dy;
 
-    double bottomPosition = toolbarRelativeOffset;
+    final double toolbarTopOffset = toolbarOffsetY - overlayOffsetY;
+
+    double bottomPosition = overlayRenderBox.size.height - toolbarTopOffset;
     if (widget.inputOptions.inputToolbarMargin != null) {
       bottomPosition -= widget.inputOptions.inputToolbarMargin!.top -
           widget.inputOptions.inputToolbarMargin!.bottom;


### PR DESCRIPTION
**Issue:** 
If there is an `Overlay` widget near `DashChat` on the widget hierarchy that only covers a portion of the screen, when the mention `OverlayEntry` shows up, it gets misplaced.

See the mention `OverlayEntry` sitting way up the screen
![Screenshot 2024-07-30 at 1 13 22 AM](https://github.com/user-attachments/assets/1d874da0-da1a-4323-9ec6-da3b86c85ec3)

**Steps to Reproduce:**
1.  Download and run this project [example.zip](https://github.com/user-attachments/files/16416735/example.zip)
2. In the source code, notice the `Overlay` widget as a parent of `DashChat` and its bounds is only the body of the `Scaffold`
2. In the app,  Go to `Mentions Example`
3. Trigger the mention dialog by typing @
4. Notice the misplaced dialog

**Proposed Solution**
Base the offset of the mention OverlayEntry relative to the nearest `Overlay` bounds
