### PR TITLE
feat: Adding optional empty placeholder in messages list

### DIFF
--- a/lib/src/models/message_list_options.dart
+++ b/lib/src/models/message_list_options.dart
@@ -14,6 +14,7 @@ class MessageListOptions {
     this.onLoadEarlier,
     this.typingBuilder,
     this.scrollPhysics,
+    this.emptyPlaceholder,
   });
 
   /// If you want to who a date separator between messages of different dates
@@ -49,6 +50,9 @@ class MessageListOptions {
 
   /// Builder to create your own typing widget
   final Widget Function(ChatUser user)? typingBuilder;
+
+  /// If you want to show a widget when there is no message
+  final Widget? emptyPlaceholder;
 
   /// Scroll physics of the ListView
   final ScrollPhysics? scrollPhysics;

--- a/lib/src/widgets/message_list/message_list.dart
+++ b/lib/src/widgets/message_list/message_list.dart
@@ -65,60 +65,70 @@ class MessageListState extends State<MessageList> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Expanded(
-                child: ListView.builder(
-                  physics: widget.messageListOptions.scrollPhysics,
-                  padding: widget.readOnly ? null : EdgeInsets.zero,
-                  controller: scrollController,
-                  reverse: true,
-                  itemCount: widget.messages.length,
-                  itemBuilder: (BuildContext context, int i) {
-                    final ChatMessage? previousMessage =
-                        i < widget.messages.length - 1
-                            ? widget.messages[i + 1]
-                            : null;
-                    final ChatMessage? nextMessage =
-                        i > 0 ? widget.messages[i - 1] : null;
-                    final ChatMessage message = widget.messages[i];
-                    final bool isAfterDateSeparator = _shouldShowDateSeparator(
-                        previousMessage, message, widget.messageListOptions);
-                    bool isBeforeDateSeparator = false;
-                    if (nextMessage != null) {
-                      isBeforeDateSeparator = _shouldShowDateSeparator(
-                          message, nextMessage, widget.messageListOptions);
-                    }
-                    return Column(
-                      children: <Widget>[
-                        if (isAfterDateSeparator)
-                          widget.messageListOptions.dateSeparatorBuilder != null
-                              ? widget.messageListOptions
-                                  .dateSeparatorBuilder!(message.createdAt)
-                              : DefaultDateSeparator(
-                                  date: message.createdAt,
-                                  messageListOptions: widget.messageListOptions,
+                child: widget.messageListOptions.emptyPlaceholder != null &&
+                        widget.messages.isEmpty
+                    ? widget.messageListOptions.emptyPlaceholder!
+                    : ListView.builder(
+                        physics: widget.messageListOptions.scrollPhysics,
+                        padding: widget.readOnly ? null : EdgeInsets.zero,
+                        controller: scrollController,
+                        reverse: true,
+                        itemCount: widget.messages.length,
+                        itemBuilder: (BuildContext context, int i) {
+                          final ChatMessage? previousMessage =
+                              i < widget.messages.length - 1
+                                  ? widget.messages[i + 1]
+                                  : null;
+                          final ChatMessage? nextMessage =
+                              i > 0 ? widget.messages[i - 1] : null;
+                          final ChatMessage message = widget.messages[i];
+                          final bool isAfterDateSeparator =
+                              _shouldShowDateSeparator(previousMessage, message,
+                                  widget.messageListOptions);
+                          bool isBeforeDateSeparator = false;
+                          if (nextMessage != null) {
+                            isBeforeDateSeparator = _shouldShowDateSeparator(
+                                message,
+                                nextMessage,
+                                widget.messageListOptions);
+                          }
+                          return Column(
+                            children: <Widget>[
+                              if (isAfterDateSeparator)
+                                widget.messageListOptions
+                                            .dateSeparatorBuilder !=
+                                        null
+                                    ? widget.messageListOptions
+                                            .dateSeparatorBuilder!(
+                                        message.createdAt)
+                                    : DefaultDateSeparator(
+                                        date: message.createdAt,
+                                        messageListOptions:
+                                            widget.messageListOptions,
+                                      ),
+                              if (widget.messageOptions.messageRowBuilder !=
+                                  null) ...<Widget>[
+                                widget.messageOptions.messageRowBuilder!(
+                                  message,
+                                  previousMessage,
+                                  nextMessage,
+                                  isAfterDateSeparator,
+                                  isBeforeDateSeparator,
                                 ),
-                        if (widget.messageOptions.messageRowBuilder !=
-                            null) ...<Widget>[
-                          widget.messageOptions.messageRowBuilder!(
-                            message,
-                            previousMessage,
-                            nextMessage,
-                            isAfterDateSeparator,
-                            isBeforeDateSeparator,
-                          ),
-                        ] else
-                          MessageRow(
-                            message: widget.messages[i],
-                            nextMessage: nextMessage,
-                            previousMessage: previousMessage,
-                            currentUser: widget.currentUser,
-                            isAfterDateSeparator: isAfterDateSeparator,
-                            isBeforeDateSeparator: isBeforeDateSeparator,
-                            messageOptions: widget.messageOptions,
-                          ),
-                      ],
-                    );
-                  },
-                ),
+                              ] else
+                                MessageRow(
+                                  message: widget.messages[i],
+                                  nextMessage: nextMessage,
+                                  previousMessage: previousMessage,
+                                  currentUser: widget.currentUser,
+                                  isAfterDateSeparator: isAfterDateSeparator,
+                                  isBeforeDateSeparator: isBeforeDateSeparator,
+                                  messageOptions: widget.messageOptions,
+                                ),
+                            ],
+                          );
+                        },
+                      ),
               ),
               if (widget.typingUsers != null && widget.typingUsers!.isNotEmpty)
                 ...widget.typingUsers!.map((ChatUser user) {


### PR DESCRIPTION
In some case, users would prefer an empty indicator to show there is no message in the conversation.

Here, I added an additional `Widget` argument to `MessageListOptions`, only show when `messageList` is empty and the argument itself is not null. Otherwise, show the `ListView`.