### PR TITLE
listStartWidget that will appear at the beginning of the chat.

### DIFF
--- a/lib/dash_chat_2.dart
+++ b/lib/dash_chat_2.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_parsed_text/flutter_parsed_text.dart';
 import 'package:intl/intl.dart' as intl;

--- a/lib/src/models/message_list_options.dart
+++ b/lib/src/models/message_list_options.dart
@@ -12,6 +12,7 @@ class MessageListOptions {
     this.showFooterBeforeQuickReplies = false,
     this.loadEarlierBuilder,
     this.onLoadEarlier,
+    this.listStartWidget,
     this.typingBuilder,
     this.scrollPhysics,
   });
@@ -45,7 +46,11 @@ class MessageListOptions {
 
   /// Function to call when the top of the list is reached
   /// Useful to load more messages
-  final Future<void> Function()? onLoadEarlier;
+  /// Returns false when we know that the next call will not load anything
+  final Future<bool?> Function()? onLoadEarlier;
+
+  /// If you want to show a widget at the very beginning of the list
+  final Widget? listStartWidget;
 
   /// Builder to create your own typing widget
   final Widget Function(ChatUser user)? typingBuilder;

--- a/lib/src/models/message_options.dart
+++ b/lib/src/models/message_options.dart
@@ -27,6 +27,7 @@ class MessageOptions {
     this.parsePatterns,
     this.textBeforeMedia = true,
     this.onTapMedia,
+    this.onTapLink,
     this.showTime = false,
     this.timeFormat,
     this.messageTimeBuilder,
@@ -197,6 +198,10 @@ class MessageOptions {
   /// Function to call when the user clicks on a media
   /// Will not work with the default video player
   final void Function(ChatMedia media)? onTapMedia;
+
+  /// Function to call when the user clicks on a link. 
+  /// Returns false when default behavior is desired.
+  final bool Function(String value, String? href, String title)? onTapLink;
 
   /// Border radius of the chat bubbles
   ///

--- a/lib/src/widgets/message_row/default_message_text.dart
+++ b/lib/src/widgets/message_row/default_message_text.dart
@@ -97,10 +97,15 @@ class DefaultMessageText extends StatelessWidget {
             selectable: true,
             styleSheet: messageOptions.markdownStyleSheet,
             onTapLink: (String value, String? href, String title) {
-              if (href != null) {
-                openLink(href);
-              } else {
-                openLink(value);
+              final bool Function(String value, String? href, String title)?
+                  customOnTapLink = messageOptions.onTapLink;
+              if (customOnTapLink == null ||
+                  !customOnTapLink(value, href, title)) {
+                if (href != null) {
+                  openLink(href);
+                } else {
+                  openLink(value);
+                }
               }
             },
           )


### PR DESCRIPTION
Fixes #116

Plays nice with onLoadEarlier.

When you don't have onLoadEarlier, it's always at the beginning of the chat log.

When you have onLoadEarlier, it's there at the beginning of the chat log in these cases:
- if the content is too short so no scroll is needed.
- if the content is long enough to scroll, it appears when onLoadEarlier returns false.

Works well in my experience. 