### PR TITLE
onTapLink in MessageOptions enables custom handling of tapping links in markdown

### DIFF
--- a/lib/src/models/message_options.dart
+++ b/lib/src/models/message_options.dart
@@ -27,6 +27,7 @@ class MessageOptions {
     this.parsePatterns,
     this.textBeforeMedia = true,
     this.onTapMedia,
+    this.onTapLink,
     this.showTime = false,
     this.timeFormat,
     this.messageTimeBuilder,
@@ -197,6 +198,10 @@ class MessageOptions {
   /// Function to call when the user clicks on a media
   /// Will not work with the default video player
   final void Function(ChatMedia media)? onTapMedia;
+
+  /// Function to call when the user clicks on a link. 
+  /// Returns false when default behavior is desired.
+  final bool Function(String value, String? href, String title)? onTapLink;
 
   /// Border radius of the chat bubbles
   ///

--- a/lib/src/widgets/message_row/default_message_text.dart
+++ b/lib/src/widgets/message_row/default_message_text.dart
@@ -97,10 +97,15 @@ class DefaultMessageText extends StatelessWidget {
             selectable: true,
             styleSheet: messageOptions.markdownStyleSheet,
             onTapLink: (String value, String? href, String title) {
-              if (href != null) {
-                openLink(href);
-              } else {
-                openLink(value);
+              final bool Function(String value, String? href, String title)?
+                  customOnTapLink = messageOptions.onTapLink;
+              if (customOnTapLink == null ||
+                  !customOnTapLink(value, href, title)) {
+                if (href != null) {
+                  openLink(href);
+                } else {
+                  openLink(value);
+                }
               }
             },
           )


### PR DESCRIPTION
When you don't provide `onTapLink`, the default action is taken with link tap.

When you provide it, it is called when a link is tapped. If you decide that the link should have been handled in the default way, you can return false from onTapLink.

Fixes #118 